### PR TITLE
Fixed non-localised DisplayNames in Schematics exporting with <>

### DIFF
--- a/BanjoBotAssets/Exporters/AssetRegistryExporter.cs
+++ b/BanjoBotAssets/Exporters/AssetRegistryExporter.cs
@@ -86,8 +86,7 @@ namespace BanjoBotAssets.Exporters
                             }
                             else
                             {
-                                // shouldn't get here...
-                                output.AddDisplayNameCorrection(schematicTemplateId, $"<{displayName.Trim()}>");
+                                output.AddDisplayNameCorrection(schematicTemplateId, displayName.Trim());
                             }
                         }
                     }


### PR DESCRIPTION
Fixed non-localised DisplayNames in Schematics exporting with arrow brackets

Schematics no longer seem to use localised texts at all, so most of that method could probably be removed altogether