### PR TITLE
Fix Default Rarities

### DIFF
--- a/BanjoBotAssets/Exporters/UObjects/UObjectExporter.cs
+++ b/BanjoBotAssets/Exporters/UObjects/UObjectExporter.cs
@@ -148,7 +148,7 @@ namespace BanjoBotAssets.Exporters.UObjects
                         itemData.Tier = (int)tier;
                     }
 
-                    if (uobject.GetOrDefault<EFortRarity>("Rarity") is EFortRarity rarity && rarity != default)
+                    if (uobject.GetOrDefault("Rarity", EFortRarity.Uncommon) is EFortRarity rarity && rarity != EFortRarity.Uncommon)
                     {
                         itemData.Rarity = rarity.GetNameText().Text;
                     }


### PR DESCRIPTION
C# thought the default EFortRarity was Common due to it being associated with 0, causing both Common and Uncommon rarities to not get exported. This commit replaces default(EFortRarity) with EFortRarity.Uncommon