### PR TITLE
Abilities now properly export their description

### DIFF
--- a/BanjoBotAssets.Json/AbilityItemData.cs
+++ b/BanjoBotAssets.Json/AbilityItemData.cs
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with BanjoBotAssets.  If not, see <http://www.gnu.org/licenses/>.
  */
+using Newtonsoft.Json;
+
 namespace BanjoBotAssets.Json
 {
     [NamedItemData("Ability")]
@@ -31,6 +33,7 @@ namespace BanjoBotAssets.Json
     /// <summary>
     /// Ability damage stats from the GadgetScaling table
     /// </summary>
+    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public sealed class AbilityStats
     {
         public float? Damage { get; set; }
@@ -39,5 +42,13 @@ namespace BanjoBotAssets.Json
         public float? BaseCritChance { get; set; }
         public float? BaseCritDamage { get; set; }
         public float? StunTime { get; set; }
+        public float? Duration { get; set; }
+        public float? FireRate { get; set; }
+        public float? Distance { get; set; }
+        public float? Radius { get; set; }
+        public float? AbilityLine2 { get; set; }
+        public float? AbilityLine3 { get; set; }
+        public float? AbilityLine4 { get; set; }
+        public float? AbilityLine5 { get; set; }
     }
 }

--- a/BanjoBotAssets/Exporters/Helpers/AbilityDescription.cs
+++ b/BanjoBotAssets/Exporters/Helpers/AbilityDescription.cs
@@ -53,7 +53,7 @@ namespace BanjoBotAssets.Exporters.Helpers
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "TODO")]
         public static async Task<string?> GetForActiveAbilityAsync(UBlueprintGeneratedClass gameplayAbilityClass, UObject gameplayAbilityCdo, IAssetCounter assetCounter, UObject? tooltipCdo = null, AbilityStats? abilityStats = null)
         {
-            if(tooltipCdo is null)
+            if (tooltipCdo is null)
             {
                 var tooltip = gameplayAbilityCdo.GetOrDefault<UBlueprintGeneratedClass?>("Tooltip");
 
@@ -67,12 +67,13 @@ namespace BanjoBotAssets.Exporters.Helpers
                 tooltipCdo = await tooltip.ClassDefaultObject.LoadAsync();
                 assetCounter.CountAssetLoaded();
             }
+
             if (tooltipCdo is null)
                 return null;
 
             string tooltipText = tooltipCdo.GetOrDefault<FText>("Description").Text;
 
-            if(abilityStats is not null)
+            if (abilityStats is not null)
             {
                 tooltipText = tooltipText
                     .Replace("+[Damage]", "+" + FormatAsPercent(abilityStats.Damage) + "%")
@@ -91,7 +92,7 @@ namespace BanjoBotAssets.Exporters.Helpers
 
                     .Replace("[Ability.Distance]", FormatAsDistance(abilityStats.Distance))
 
-                    .Replace("[Radius]", FormatAsDistance(abilityStats.Radius)+" tile")
+                    .Replace("[Radius]", FormatAsDistance(abilityStats.Radius) + " tile")
 
                     .Replace("[Duration]", FormatAsRegular(abilityStats.Duration))
                     .Replace("[Ability.Duration]", FormatAsRegular(abilityStats.Duration));
@@ -104,6 +105,7 @@ namespace BanjoBotAssets.Exporters.Helpers
         {
             return value?.ToString(CultureInfo.InvariantCulture) ?? "?";
         }
+
         private static string FormatAsPercent(float? value)
         {
             if (value is null)
@@ -111,6 +113,7 @@ namespace BanjoBotAssets.Exporters.Helpers
             int primaryDigits = ((int)((value - 1) * 2000));
             return (primaryDigits * 0.05f).ToString(CultureInfo.InvariantCulture);
         }
+
         private static string FormatAsDistance(float? value)
         {
             if (value is null)

--- a/BanjoBotAssets/Exporters/Helpers/AbilityDescription.cs
+++ b/BanjoBotAssets/Exporters/Helpers/AbilityDescription.cs
@@ -51,22 +51,72 @@ namespace BanjoBotAssets.Exporters.Helpers
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1163:Unused parameter", Justification = "TODO")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "TODO")]
-        public static async Task<string?> GetForActiveAbilityAsync(UBlueprintGeneratedClass gameplayAbilityClass, UObject gameplayAbilityCdo, IAssetCounter assetCounter)
+        public static async Task<string?> GetForActiveAbilityAsync(UBlueprintGeneratedClass gameplayAbilityClass, UObject gameplayAbilityCdo, IAssetCounter assetCounter, UObject? tooltipCdo = null, AbilityStats? abilityStats = null)
         {
-            // TODO: use gameplayAbilityClass to substitute the correct token values
-            var tooltip = gameplayAbilityCdo.GetOrDefault<UBlueprintGeneratedClass?>("ToolTip");
-
-            if (tooltip == null)
+            if(tooltipCdo is null)
             {
+                var tooltip = gameplayAbilityCdo.GetOrDefault<UBlueprintGeneratedClass?>("ToolTip");
+
+                if (tooltip == null)
+                {
+                    return null;
+                }
+
+                assetCounter.CountAssetLoaded();
+
+                tooltipCdo = await tooltip.ClassDefaultObject.LoadAsync();
+                assetCounter.CountAssetLoaded();
+            }
+            if (tooltipCdo is null)
                 return null;
+
+            string tooltipText = tooltipCdo.GetOrDefault<FText>("Description").Text;
+
+            if(abilityStats is not null)
+            {
+                tooltipText = tooltipText
+                    .Replace("+[Damage]", "+" + FormatAsPercent(abilityStats.Damage) + "%")
+                    .Replace("+[Ability.Line4]", "+" + FormatAsPercent(abilityStats.AbilityLine4) + "%")
+                    .Replace("+[Ability.Line5]", "+" + FormatAsPercent(abilityStats.AbilityLine5) + "%")
+
+                    .Replace("[Damage]", FormatAsRegular(abilityStats.Damage))
+                    .Replace("[Damage.Value]", FormatAsRegular(abilityStats.Damage))
+                    .Replace("[AbilityWeaponDamage.Value]", FormatAsRegular(abilityStats.Damage))
+
+                    .Replace("[Ability.Line2]", FormatAsRegular(abilityStats.AbilityLine2))
+                    .Replace("[Ability.Line3]", FormatAsRegular(abilityStats.AbilityLine3))
+
+                    .Replace("[FireRate.Value]", FormatAsRegular(abilityStats.FireRate))
+                    .Replace("[Ability.RateOfFire]", FormatAsRegular(abilityStats.FireRate))
+
+                    .Replace("[Ability.Distance]", FormatAsDistance(abilityStats.Distance))
+
+                    .Replace("[Radius]", FormatAsDistance(abilityStats.Radius)+" tile")
+
+                    .Replace("[Duration]", FormatAsRegular(abilityStats.Duration))
+                    .Replace("[Ability.Duration]", FormatAsRegular(abilityStats.Duration));
             }
 
-            assetCounter.CountAssetLoaded();
+            return tooltipText;
+        }
 
-            var tooltipCdo = await tooltip.ClassDefaultObject.LoadAsync();
-            assetCounter.CountAssetLoaded();
-
-            return tooltipCdo?.GetOrDefault<FText>("Description").Text;
+        private static string FormatAsRegular(float? value)
+        {
+            return value?.ToString(CultureInfo.InvariantCulture) ?? "?";
+        }
+        private static string FormatAsPercent(float? value)
+        {
+            if (value is null)
+                return "?";
+            int primaryDigits = ((int)((value - 1) * 2000));
+            return (primaryDigits * 0.05f).ToString(CultureInfo.InvariantCulture);
+        }
+        private static string FormatAsDistance(float? value)
+        {
+            if (value is null)
+                return "?";
+            //bull rush allegedly travels 1 tile more than it's distance parameter
+            return ((float)(value / 512)).ToString(CultureInfo.InvariantCulture);
         }
 
         private static async Task<(string? markup, UObject? tooltip)> GetMarkupAsync(UObject grantedAbilityKit, IAssetCounter assetCounter)

--- a/BanjoBotAssets/Exporters/Helpers/AbilityDescription.cs
+++ b/BanjoBotAssets/Exporters/Helpers/AbilityDescription.cs
@@ -55,7 +55,7 @@ namespace BanjoBotAssets.Exporters.Helpers
         {
             if(tooltipCdo is null)
             {
-                var tooltip = gameplayAbilityCdo.GetOrDefault<UBlueprintGeneratedClass?>("ToolTip");
+                var tooltip = gameplayAbilityCdo.GetOrDefault<UBlueprintGeneratedClass?>("Tooltip");
 
                 if (tooltip == null)
                 {

--- a/BanjoBotAssets/Exporters/UObjects/AbilityExporter.cs
+++ b/BanjoBotAssets/Exporters/UObjects/AbilityExporter.cs
@@ -141,7 +141,7 @@ namespace BanjoBotAssets.Exporters.UObjects
             var damageStats = gadget.DamageStatHandle;
             if (damageStats != null)
             {
-                FStructFallback? row = gadgetTable?.TryGetValue(damageStats.RowName.Text, out var gadgetRow)==true ? gadgetRow : null;
+                FStructFallback? row = gadgetTable?.TryGetValue(damageStats.RowName.Text, out var gadgetRow) == true ? gadgetRow : null;
                 row ??= meleeTable?.TryGetValue(damageStats.RowName.Text, out var meleeRow) == true ? meleeRow : null;
                 row ??= rangedTable?.TryGetValue(damageStats.RowName.Text, out var rangedRow) == true ? rangedRow : null;
 
@@ -194,6 +194,7 @@ namespace BanjoBotAssets.Exporters.UObjects
 
             namedItemData.AbilityStats ??= new();
 
+            // TODO: instead of hardcoding the definitions of each token, ideally we'd extract them from the ability asset itself
             // load extra ability stats from GameplayAbility
             // plasma pulse
             namedItemData.AbilityStats.Duration ??= GetStatFromGameplayAbility(gaCdo, "Pulse Duration");
@@ -225,8 +226,8 @@ namespace BanjoBotAssets.Exporters.UObjects
             // war cry
             namedItemData.AbilityStats.Damage ??= GetStatFromTooltip(tooltipCdo, "SF_DamageMult");
             namedItemData.AbilityStats.AbilityLine4 ??= GetStatFromTooltip(tooltipCdo, "SF_AttackSpeed", true);
-            namedItemData.AbilityStats.FireRate ??= 
-            namedItemData.AbilityStats.AbilityLine5 ??= GetStatFromTooltip(tooltipCdo, "SF_FireRate", true);
+            namedItemData.AbilityStats.FireRate ??=
+                namedItemData.AbilityStats.AbilityLine5 ??= GetStatFromTooltip(tooltipCdo, "SF_FireRate", true);
 
             // goin constructor
             namedItemData.AbilityStats.AbilityLine2 ??= GetStatFromTooltip(tooltipCdo, "ShieldBlock_Percentage");
@@ -266,6 +267,14 @@ namespace BanjoBotAssets.Exporters.UObjects
         }
 
         bool tooltipStatLastSuccess;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="tooltipCdo"></param>
+        /// <param name="property"></param>
+        /// <param name="chain"><see langword="true"/> if this stat is dependent on a previous stat being found</param>
+        /// <returns></returns>
         private float? GetStatFromTooltip(UObject? tooltipCdo, string property, bool chain = false)
         {
             if (chain && !tooltipStatLastSuccess)
@@ -275,7 +284,16 @@ namespace BanjoBotAssets.Exporters.UObjects
             tooltipStatLastSuccess = result is not null;
             return result;
         }
+
         bool gameplayAbilityStatLastSuccess;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="gaCdo"></param>
+        /// <param name="property"></param>
+        /// <param name="chain"><see langword="true"/> if this stat is dependent on a previous stat being found</param>
+        /// <returns></returns>
         private float? GetStatFromGameplayAbility(UObject gaCdo, string property, bool chain = false)
         {
             if (chain && !gameplayAbilityStatLastSuccess)


### PR DESCRIPTION
By collecting extra stats from the Melee and Ranged Datatables instead of just the Gadget Datatable, and pulling in extra stats from the gameplay ability definitions, all description tokens are replaceable by their in-game values
Resolves #45 