### PR TITLE
Implemented Expedition Exporters

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
         source-url: https://nuget.pkg.github.com/BanjoByTheBay/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/BanjoBotAssets.Json/ExpeditionCriteria.cs
+++ b/BanjoBotAssets.Json/ExpeditionCriteria.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BanjoBotAssets.Json
+{
+    public sealed class ExpeditionCriteria
+    {
+        [DisallowNull]
+        public string? RequiredTag { get; set; }
+        public string? RequiredRarity { get; set; }
+        [DisallowNull]
+        public float ModValue { get; set; }
+    }
+}

--- a/BanjoBotAssets.Json/ExpeditionItemData.cs
+++ b/BanjoBotAssets.Json/ExpeditionItemData.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BanjoBotAssets.Json
+{
+    [NamedItemData("Expedition")]
+    public sealed class ExpeditionItemData : NamedItemData
+    {
+        [DisallowNull]
+        public int? ResearchCost { get; set; }
+        [DisallowNull]
+        public string? ExpeditionType { get; set; }
+        [DisallowNull]
+        public string? ExpeditionReward { get; set; }
+    }
+}

--- a/BanjoBotAssets.Json/ExportedAssets.cs
+++ b/BanjoBotAssets.Json/ExportedAssets.cs
@@ -29,6 +29,7 @@ namespace BanjoBotAssets.Json
 
         public ItemRatingTables ItemRatings { get; } = new();
 
+        public SortedDictionary<string, ExpeditionCriteria> ExpeditionCriteria { get; } = new(StringComparer.OrdinalIgnoreCase);
         public SortedDictionary<string, DifficultyInfo> DifficultyInfo { get; } = new(StringComparer.OrdinalIgnoreCase);
 
         public SortedDictionary<string, string[][]> MainQuestLines { get; } = [];
@@ -63,6 +64,14 @@ namespace BanjoBotAssets.Json
 
                 if (other.ItemRatings.LeadSurvivor != null)
                     ItemRatings.LeadSurvivor = other.ItemRatings.LeadSurvivor;
+            }
+
+            if (other.ExpeditionCriteria != null)
+            {
+                foreach (var (k, v) in other.ExpeditionCriteria)
+                {
+                    ExpeditionCriteria[k] = v;
+                }
             }
 
             if (other.DifficultyInfo != null)

--- a/BanjoBotAssets/Exporters/ExpeditionCriteriaExporter.cs
+++ b/BanjoBotAssets/Exporters/ExpeditionCriteriaExporter.cs
@@ -1,0 +1,51 @@
+﻿using CUE4Parse.UE4.Objects.GameplayTags;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BanjoBotAssets.Exporters
+{
+    internal sealed class ExpeditionCriteriaExporter(IExporterContext services) : BaseExporter(services)
+    {
+        public override async Task ExportAssetsAsync(IProgress<ExportProgress> progress, IAssetOutput output, CancellationToken cancellationToken)
+        {
+            var criteriaPath = assetPaths.First(p => Path.GetFileNameWithoutExtension(p).Equals("ExpeditionCriteriaRequirements", StringComparison.OrdinalIgnoreCase));
+
+            if (criteriaPath == null)
+            {
+                logger.LogError(Resources.Error_SpecificAssetNotFound, "ExpeditionCriteriaRequirements");
+                return;
+            }
+
+            var file = provider[criteriaPath];
+
+            Interlocked.Increment(ref assetsLoaded);
+            var dataTable = await provider.LoadObjectAsync<UDataTable>(file.PathWithoutExtension);
+
+            if (dataTable == null)
+            {
+                logger.LogError(Resources.Warning_CouldNotLoadAsset, criteriaPath);
+                return;
+            }
+
+            foreach (var (rowKey, data) in dataTable.RowMap)
+            {
+                var requiredTag = data.GetOrDefault<FGameplayTag>("RequiredTag").TagName.Text;
+                var hasRequiredRarity = data.GetOrDefault<bool>("bRequireRarity");
+                var requiredRarity = data.GetOrDefault<EFortRarity>("RequiredRarity");
+                var modValue = data.GetOrDefault<float>("ModValue");
+
+                output.AddExpeditionCriteria(rowKey.Text, new ExpeditionCriteria
+                {
+                    RequiredTag = requiredTag,
+                    RequiredRarity = hasRequiredRarity ? requiredRarity.GetNameText().Text : null,
+                    ModValue = modValue
+                });
+            }
+        }
+
+        protected override bool InterestedInAsset(string name) => name.EndsWith("ExpeditionCriteriaRequirements.uasset", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/BanjoBotAssets/Exporters/ExpeditionCriteriaExporter.cs
+++ b/BanjoBotAssets/Exporters/ExpeditionCriteriaExporter.cs
@@ -1,9 +1,4 @@
 ﻿using CUE4Parse.UE4.Objects.GameplayTags;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BanjoBotAssets.Exporters
 {

--- a/BanjoBotAssets/Exporters/Helpers/AssetOutput.cs
+++ b/BanjoBotAssets/Exporters/Helpers/AssetOutput.cs
@@ -16,6 +16,7 @@
  * along with BanjoBotAssets.  If not, see <http://www.gnu.org/licenses/>.
  */
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace BanjoBotAssets.Exporters.Helpers
 {
@@ -25,6 +26,7 @@ namespace BanjoBotAssets.Exporters.Helpers
         private readonly ConcurrentDictionary<string, NamedItemData> namedItems = new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<ImageType, ConcurrentDictionary<string, string>> namedItemImages = new();
         private readonly ConcurrentDictionary<string, DifficultyInfo> difficultyInfo = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, ExpeditionCriteria> expeditionCriteria = new(StringComparer.OrdinalIgnoreCase);
 
         private readonly ConcurrentDictionary<string, IReadOnlyDictionary<string, int>> craftingRecipes = new(StringComparer.OrdinalIgnoreCase);
 
@@ -45,6 +47,11 @@ namespace BanjoBotAssets.Exporters.Helpers
         public void AddDefaultItemRatings(ItemRatingTable itemRatings)
         {
             defaultItemRatings = itemRatings;
+        }
+
+        public void AddExpeditionCriteria(string name, ExpeditionCriteria expeditionCriteria)
+        {
+            this.expeditionCriteria.TryAdd(name, expeditionCriteria);
         }
 
         public void AddDifficultyInfo(string name, DifficultyInfo difficultyInfo)
@@ -92,6 +99,13 @@ namespace BanjoBotAssets.Exporters.Helpers
                     ni.ImagePaths ??= [];
                     ni.ImagePaths.TryAdd(imageType, v);
                 }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var (k, v) in expeditionCriteria)
+            {
+                exportedAssets.ExpeditionCriteria.TryAdd(k, v);
             }
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/BanjoBotAssets/Exporters/Helpers/AssetOutput.cs
+++ b/BanjoBotAssets/Exporters/Helpers/AssetOutput.cs
@@ -16,7 +16,6 @@
  * along with BanjoBotAssets.  If not, see <http://www.gnu.org/licenses/>.
  */
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 
 namespace BanjoBotAssets.Exporters.Helpers
 {

--- a/BanjoBotAssets/Exporters/Helpers/IAssetOutput.cs
+++ b/BanjoBotAssets/Exporters/Helpers/IAssetOutput.cs
@@ -30,6 +30,8 @@ namespace BanjoBotAssets.Exporters.Helpers
         /// <param name="assetPath">The path of the image asset.</param>
         void AddImageForNamedItem(string name, ImageType type, string assetPath);
 
+        void AddExpeditionCriteria(string name, ExpeditionCriteria expeditionCriteria);
+
         void AddDifficultyInfo(string name, DifficultyInfo difficultyInfo);
 
         void AddDefaultItemRatings(ItemRatingTable itemRatings);

--- a/BanjoBotAssets/Exporters/UObjects/ExpeditionExporter.cs
+++ b/BanjoBotAssets/Exporters/UObjects/ExpeditionExporter.cs
@@ -1,0 +1,35 @@
+﻿using BanjoBotAssets.UExports;
+using CUE4Parse.FN.Structs.GA;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BanjoBotAssets.Exporters.UObjects
+{
+    internal sealed class ExpeditionExporter(IExporterContext services) : UObjectExporter<UObject, ExpeditionItemData>(services)
+    {
+        protected override string Type => "Expedition";
+
+        protected override bool InterestedInAsset(string name)
+        {
+            return name.Contains("/Expeditions/Expedition_", StringComparison.OrdinalIgnoreCase);
+        }
+
+        protected override Task<bool> ExportAssetAsync(UObject asset, ExpeditionItemData itemData, Dictionary<ImageType, string> imagePaths)
+        {
+            if (asset.GetOrDefault<FDataTableRowHandle>("ExpeditionRules") is FDataTableRowHandle expeditionRules && 
+                expeditionRules.DataTable.TryGetDataTableRow(expeditionRules.RowName.Text, StringComparison.OrdinalIgnoreCase, out var rulesRow))
+            {
+                FRecipe rulesRecipe = new(rulesRow);
+                itemData.ResearchCost = rulesRecipe.RecipeCosts.Length > 0 ? rulesRecipe.RecipeCosts[0].Quantity : 0;
+                itemData.ExpeditionType = rulesRecipe.RequiredCatalysts.GameplayTags[0].TagName.Text;
+                var reward = rulesRecipe.RecipeResults[0].ItemPrimaryAssetId;
+                //is there a better way to format rewards?
+                itemData.ExpeditionReward = $"{reward.PrimaryAssetType.Name.Text}:{reward.PrimaryAssetName.Text}";
+            }
+            return base.ExportAssetAsync(asset, itemData, imagePaths);
+        }
+    }
+}

--- a/BanjoBotAssets/Exporters/UObjects/ExpeditionExporter.cs
+++ b/BanjoBotAssets/Exporters/UObjects/ExpeditionExporter.cs
@@ -1,10 +1,4 @@
 ﻿using BanjoBotAssets.UExports;
-using CUE4Parse.FN.Structs.GA;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BanjoBotAssets.Exporters.UObjects
 {

--- a/BanjoBotAssets/UExports/FRecipe.cs
+++ b/BanjoBotAssets/UExports/FRecipe.cs
@@ -16,6 +16,7 @@
  * along with BanjoBotAssets.  If not, see <http://www.gnu.org/licenses/>.
  */
 using CUE4Parse.UE4.Assets.Utils;
+using CUE4Parse.UE4.Objects.GameplayTags;
 
 namespace BanjoBotAssets.UExports
 {
@@ -27,7 +28,7 @@ namespace BanjoBotAssets.UExports
         public bool bIsConsumed { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
         public FFortItemQuantityPair[] RecipeCosts { get; set; }
-        public FFortItemQuantityPair[] RequiredCatalysts { get; set; }
+        public FGameplayTagContainer RequiredCatalysts { get; set; }
         public int Score { get; set; }
 
         public FRecipe(FStructFallback fallback)
@@ -35,7 +36,7 @@ namespace BanjoBotAssets.UExports
             RecipeResults = fallback.GetOrDefault<FFortItemQuantityPair[]>(nameof(RecipeResults));
             bIsConsumed = fallback.GetOrDefault<bool>(nameof(bIsConsumed));
             RecipeCosts = fallback.GetOrDefault<FFortItemQuantityPair[]>(nameof(RecipeCosts));
-            RequiredCatalysts = fallback.GetOrDefault<FFortItemQuantityPair[]>(nameof(RequiredCatalysts));
+            RequiredCatalysts = fallback.GetOrDefault<FGameplayTagContainer>(nameof(RequiredCatalysts));
             Score = fallback.GetOrDefault<int>(nameof(Score));
         }
     }


### PR DESCRIPTION
Implemented exporters for both Expedition items and the ExpeditionCriteriaRequirements data table. Also fixes an issue in FRecipe where the RequiredCatalysts property was interpreted as an FFortItemQuantityPair array instead of an FGameplayTagContainer